### PR TITLE
Drop interrogate coverage of tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,5 @@ line_length = 79
 profile = "black"
 
 [tool.interrogate]
-exclude = ["setup.py", "docs", "build"]
+exclude = ["setup.py", "docs", "build", "tests"]
 fail-under = 100


### PR DESCRIPTION
Enforcing that all tests have doc strings seems like extra work for little benefit, and the doc string is often not informative.