### PR TITLE
Accidentally used base-1 indexing instead of base-0

### DIFF
--- a/tests/test_file_io_obj_files.py
+++ b/tests/test_file_io_obj_files.py
@@ -23,11 +23,11 @@ class ObjFilesTest(unittest.TestCase):
     ]
     scene_mock.mesh_list = [MagicMock(), MagicMock()]
     scene_mock.mesh_list[0].faces = [
-        [1, 2, 3],
-        [1, 3, 4],
+        [0, 2, 3],
+        [0, 3, 4],
         [2, 3, 4],
-        [3, 4, 5],
-        [1, 3, 5],
+        [1, 2, 4],
+        [1, 3, 4],
     ]
     scene_mock.mesh_list[1].faces = scene_mock.mesh_list[0].faces
 


### PR DESCRIPTION
This is a quick fix to a test. It's not failing, but that's because the test doesn't check that the faces use valid indices.