### PR TITLE
Add function to handle changing anatomical coordinate systems

### DIFF
--- a/src/aind_mri_utils/coordinate_systems.py
+++ b/src/aind_mri_utils/coordinate_systems.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def _find_coordinate_perm_and_flips(src: str, dst: str):  # noqa: C901
+def find_coordinate_perm_and_flips(src: str, dst: str):  # noqa: C901
     """Determine how to convert between coordinate systems
 
     This function takes a source `src` and destination `dst` string specifying
@@ -122,7 +122,7 @@ def convert_coordinate_system(
     out : np.ndarray (N x M)
         The N input points transformed into the destination coordinate system
     """
-    perm, direction = _find_coordinate_perm_and_flips(src_coord, dst_coord)
+    perm, direction = find_coordinate_perm_and_flips(src_coord, dst_coord)
     out = arr[:, perm]
     out *= direction
     return out

--- a/tests/test_coordinate_systems.py
+++ b/tests/test_coordinate_systems.py
@@ -44,38 +44,38 @@ class CoordinateSystemsTest(unittest.TestCase):
             int_target_data.dtype == int_transformed_test_data.dtype
         )
 
-    def test__find_coordinate_perm_and_flips(self) -> None:
-        perm, direction = cs._find_coordinate_perm_and_flips("RAS", "LPI")
+    def test_find_coordinate_perm_and_flips(self) -> None:
+        perm, direction = cs.find_coordinate_perm_and_flips("RAS", "LPI")
         self.assertTrue(
             np.array_equal(perm, [0, 1, 2])
             and np.array_equal(direction, [-1, -1, -1])
         )
-        perm, direction = cs._find_coordinate_perm_and_flips("ras", "LPI")
+        perm, direction = cs.find_coordinate_perm_and_flips("ras", "LPI")
         self.assertTrue(
             np.array_equal(perm, [0, 1, 2])
             and np.array_equal(direction, [-1, -1, -1])
         )
-        perm, direction = cs._find_coordinate_perm_and_flips("RAS", "RAS")
+        perm, direction = cs.find_coordinate_perm_and_flips("RAS", "RAS")
         self.assertTrue(
             np.array_equal(perm, [0, 1, 2])
             and np.array_equal(direction, [1, 1, 1])
         )
-        perm, direction = cs._find_coordinate_perm_and_flips("ASR", "RAS")
+        perm, direction = cs.find_coordinate_perm_and_flips("ASR", "RAS")
         self.assertTrue(
             np.array_equal(perm, [2, 0, 1])
             and np.array_equal(direction, [1, 1, 1])
         )
-        perm, direction = cs._find_coordinate_perm_and_flips("PIL", "RAS")
+        perm, direction = cs.find_coordinate_perm_and_flips("PIL", "RAS")
         self.assertTrue(
             np.array_equal(perm, [2, 0, 1])
             and np.array_equal(direction, [-1, -1, -1])
         )
-        perm, direction = cs._find_coordinate_perm_and_flips("PLS", "LPS")
+        perm, direction = cs.find_coordinate_perm_and_flips("PLS", "LPS")
         self.assertTrue(
             np.array_equal(perm, [1, 0, 2])
             and np.array_equal(direction, [1, 1, 1])
         )
-        perm, direction = cs._find_coordinate_perm_and_flips("PRS", "LPS")
+        perm, direction = cs.find_coordinate_perm_and_flips("PRS", "LPS")
         self.assertTrue(
             np.array_equal(perm, [1, 0, 2])
             and np.array_equal(direction, [-1, 1, 1])
@@ -83,49 +83,49 @@ class CoordinateSystemsTest(unittest.TestCase):
         self.assertRaisesRegex(
             ValueError,
             "Inputs should be the same length",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RA",
             "RAS",
         )
         self.assertRaisesRegex(
             ValueError,
             "Source axis 'R' not unique",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RRS",
             "RAS",
         )
         self.assertRaisesRegex(
             ValueError,
             "Source axis 'L' not unique",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RLS",
             "RAS",
         )
         self.assertRaisesRegex(
             ValueError,
             "Destination axis 'L' not unique",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RAS",
             "RLS",
         )
         self.assertRaisesRegex(
             ValueError,
             "Source direction 'D' not in R/L, A/P, or I/S",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RAD",
             "RAS",
         )
         self.assertRaisesRegex(
             ValueError,
             "Destination direction 'D' not in R/L, A/P, or I/S",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RAS",
             "RAD",
         )
         self.assertRaisesRegex(
             ValueError,
             "Destination direction 'S' has no match in source directions 'RA'",
-            cs._find_coordinate_perm_and_flips,
+            cs.find_coordinate_perm_and_flips,
             "RA",
             "RS",
         )


### PR DESCRIPTION
Instead of making a bunch of one-off functions to handle each pair of coordinate systems you could change between, I have written a function `convert_coordinate_system` that converts between two coordinate systems specified as strings.

This is a breaking change, as I have removed `ras_to_lps` and `lps_to_ras`, but since these functions are not being used I do not plan to increase the major version number.