### PR TITLE
Fix: markup_json_to_dict used wrong number of returns

### DIFF
--- a/src/aind_mri_utils/file_io/slicer_files.py
+++ b/src/aind_mri_utils/file_io/slicer_files.py
@@ -155,7 +155,7 @@ def load_segmentation_points(
         )
 
 
-def markup_json_to_numpy(filename):  # pragma: no cover
+def markup_json_to_numpy(filename):
     """
     Extract control points from a 3D Slicer generated markup JSON file
 
@@ -175,7 +175,7 @@ def markup_json_to_numpy(filename):  # pragma: no cover
     return extract_control_points(data)
 
 
-def markup_json_to_dict(filename):  # pragma: no cover
+def markup_json_to_dict(filename):
     """
     Extract control points from a 3D Slicer generated markup JSON file
 
@@ -192,8 +192,8 @@ def markup_json_to_dict(filename):  # pragma: no cover
 
 
     """
-    pos, names = markup_json_to_numpy(filename)
-    return dict(zip(names, pos))
+    pos, names, coord_string = markup_json_to_numpy(filename)
+    return dict(zip(names, pos)), coord_string
 
 
 def create_slicer_fcsv(filename, pts_dict, direction="LPS"):


### PR DESCRIPTION
Fix markup_json_to_dict which called markup_json_to_numpy but used the wrong number of returns for this function.

slicer_files is rife with `#pragma: no cover`, hiding this bug and maybe others. I have removed the pragmas for markup_json functions, but have not yet implemented tests.