### PR TITLE
Add reticle calibration and rotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "aind_mri_utils"
 description = "MRI utilities library for aind teams."
-license = {text = "MIT"}
+license = { text = "MIT" }
 requires-python = ">=3.7"
 authors = [
-    {name = "Allen Institute for Neural Dynamics"},
-    {name = "Galen Lynch", email = "galen@galenlynch.com"},
-    {name = "Yoni Browning", email = "yoni.browning@alleninstitute.org"}
+    { name = "Allen Institute for Neural Dynamics" },
+    { name = "Galen Lynch", email = "galen@galenlynch.com" },
+    { name = "Yoni Browning", email = "yoni.browning@alleninstitute.org" },
 ]
-classifiers = [
-    "Programming Language :: Python :: 3"
-]
+classifiers = ["Programming Language :: Python :: 3"]
 readme = "README.md"
 dynamic = ["version"]
 
@@ -29,21 +27,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    'black',
-    'coverage',
-    'flake8',
-    'interrogate',
-    'isort',
-    'Sphinx',
-    'furo'
-]
+dev = ['black', 'coverage', 'flake8', 'interrogate', 'isort', 'Sphinx', 'furo']
 
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools.dynamic]
-version = {attr = "aind_mri_utils.__version__"}
+version = { attr = "aind_mri_utils.__version__" }
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     'pywavefront >= 1.3, < 2',
     'scipy >= 1, < 2',
     'SimpleITK >= 2, < 3',
-    'vtk >= 9, < 10'
+    'vtk >= 9, < 10',
+    'openpyxl >= 3, < 4',
 ]
 
 [project.optional-dependencies]

--- a/src/aind_mri_utils/optimization.py
+++ b/src/aind_mri_utils/optimization.py
@@ -4,7 +4,7 @@ Functions for optimizing volume fits.
 
 """
 import numpy as np
-from scipy.optimize import fmin
+from scipy import optimize as opt
 
 from .measurement import dist_point_to_line, dist_point_to_plane
 
@@ -276,7 +276,7 @@ def optimize_transform_labeled_lines(
 
     weights = _preprocess_weights(weights, positions, normalize, gamma)
 
-    output = fmin(
+    output = opt.fmin(
         cost_function_weighted_labeled_lines,
         init,
         args=(pts1, pts2, positions, labels, weights),
@@ -352,7 +352,7 @@ def optimize_transform_labeled_lines_with_plane(
     """
     weights = _preprocess_weights(weights, positions, normalize, gamma)
 
-    output_a = fmin(
+    output_a = opt.fmin(
         cost_function_weighted_labeled_lines,
         init,
         args=(pts1, pts2, positions, labels, weights),
@@ -360,7 +360,7 @@ def optimize_transform_labeled_lines_with_plane(
         maxfun=maxfun,
     )
 
-    output_b = fmin(
+    output_b = opt.fmin(
         cost_function_weighted_labeled_lines_with_plane,
         output_a,
         args=(pts1, pts2, pts_for_line, positions, labels, weights),

--- a/src/aind_mri_utils/plots.py
+++ b/src/aind_mri_utils/plots.py
@@ -70,7 +70,7 @@ def make_3d_ax_look_normal(ax: plt.Axes):
     Changes the aspect ratio of a 3d plot so that dimensions are approximately
     the same size
 
-     Parameters
+    Parameters
     ==========
     ax - matplotlib 3d axis
     """

--- a/src/aind_mri_utils/reticle_calibrations.py
+++ b/src/aind_mri_utils/reticle_calibrations.py
@@ -1,0 +1,216 @@
+import numpy as np
+from scipy import optimize as opt
+from scipy.spatial.transform import Rotation
+from . import rotations
+from . import utils as ut
+
+from openpyxl import load_workbook
+
+
+def extract_calibration_metadata(ws):
+    rowiter = ws.iter_rows(min_row=1, max_row=2, values_only=True)
+    colname_lookup = {k: i for i, k in enumerate(next(rowiter))}
+    metadata_values = next(rowiter)
+    global_factor = metadata_values[colname_lookup["GlobalFactor"]]
+    global_rotation_degrees = metadata_values[
+        colname_lookup["GlobalRotationDegrees"]
+    ]
+    manipulator_factor = metadata_values[colname_lookup["ManipulatorFactor"]]
+    reticle_name = metadata_values[colname_lookup["Reticule"]]
+    offset_x_pos = colname_lookup["GlobalOffsetX"]
+    global_offset = np.array(
+        metadata_values[offset_x_pos : offset_x_pos + 3], dtype=float
+    )
+    return (
+        global_factor,
+        global_rotation_degrees,
+        manipulator_factor,
+        global_offset,
+        reticle_name,
+    )
+
+
+def extract_calibration_pairs(ws):
+    pairs_by_probe = dict()
+    for row in ws.iter_rows(min_row=2, max_col=7, values_only=True):
+        probe_name = row[0]
+        if probe_name is None:
+            continue
+        reticle_pt = np.array(row[1:4])
+        probe_pt = np.array(row[4:7])
+        if probe_name not in pairs_by_probe:
+            pairs_by_probe[probe_name] = []
+        pairs_by_probe[probe_name].append((reticle_pt, probe_pt))
+    return pairs_by_probe
+
+
+def _combine_pairs(list_of_pairs):
+    global_pts, manipulator_pts = [np.vstack(x) for x in zip(*list_of_pairs)]
+    return global_pts, manipulator_pts
+
+
+def _apply_metadata_to_pair_mats(
+    global_pts,
+    manipulator_pts,
+    global_factor,
+    global_rotation_degrees,
+    global_offset,
+    manipulator_factor,
+):
+    if global_rotation_degrees != 0:
+        rotmat = (
+            Rotation.from_euler("z", global_rotation_degrees, degrees=True)
+            .as_matrix()
+            .squeeze()
+        )
+        # Transposed because points are row vectors
+        global_pts = global_pts @ rotmat.T
+    global_pts = global_pts * global_factor + global_offset
+    manipulator_pts = manipulator_pts * manipulator_factor
+    return global_pts, manipulator_pts
+
+
+def _apply_metadata_to_pair_lists(
+    list_of_pairs,
+    global_factor,
+    global_rotation_degrees,
+    global_offset,
+    manipulator_factor,
+):
+    global_pts, manipulator_pts = _combine_pairs(list_of_pairs)
+    return _apply_metadata_to_pair_mats(
+        global_pts,
+        manipulator_pts,
+        global_factor,
+        global_rotation_degrees,
+        global_offset,
+        manipulator_factor,
+    )
+
+
+def read_reticle_calibration(
+    filename, points_sheet_name="points", metadata_sheet_name="metadata"
+):
+    wb = load_workbook(filename, read_only=True, data_only=True)
+    if points_sheet_name not in wb.sheetnames:
+        raise ValueError(f"Sheet {points_sheet_name} not found in {filename}")
+    if metadata_sheet_name not in wb.sheetnames:
+        raise ValueError(
+            f"Sheet {metadata_sheet_name} not found in {filename}"
+        )
+    (
+        global_factor,
+        global_rotation_degrees,
+        manipulator_factor,
+        global_offset,
+        reticle_name,
+    ) = extract_calibration_metadata(wb[metadata_sheet_name])
+    pairs_by_probe = extract_calibration_pairs(wb["points"])
+    adjusted_pairs_by_probe = {
+        k: _apply_metadata_to_pair_lists(
+            v,
+            global_factor,
+            global_rotation_degrees,
+            global_offset,
+            manipulator_factor,
+        )
+        for k, v in pairs_by_probe.items()
+    }
+    return (
+        adjusted_pairs_by_probe,
+        global_offset,
+        global_rotation_degrees,
+        reticle_name,
+    )
+
+
+def _unpack_theta(theta):
+    R = rotations.combine_angles(*theta[0:3])
+    offset = theta[3:6]
+    return R, offset
+
+
+def fit_rotation_params(reticle_pts, probe_pts, legacy_outputs=False):
+    R_homog = np.eye(4)
+    reticle_pts_homog = ut.prepare_data_for_homogeneous_transform(reticle_pts)
+    transformed_pts_homog = np.empty_like(reticle_pts_homog)
+
+    def fun(theta):
+        R_homog[0:3, 0:3] = rotations.combine_angles(*theta[0:3])
+        R_homog[0:3, 3] = theta[3:6]  # translation
+        np.matmul(reticle_pts_homog, R_homog.T, out=transformed_pts_homog)
+        residuals = (transformed_pts_homog[:, 0:3] - probe_pts).flatten()
+        return residuals
+
+    theta0 = np.zeros(6)
+    res = opt.least_squares(fun, theta0)
+    R, translation = _unpack_theta(res.x)
+    if legacy_outputs:
+        # last version had translation in global frame
+        #
+        # All of the transposes are confusing here: this is the inverse of the
+        # rotation matrix, accounting for numpy being row-major, and
+        # data points being row vectors
+        #
+        # Also the last version found the tranpose of the rotation matrix
+        # for some reason the application of the rotation matrix without
+        # tranpose and was consistent if not correct
+        translation = translation @ R  # Not R.T!
+        return translation, R.T  # Not R!
+    return R, translation
+
+
+def apply_rotate_translate(pts, R, translation):
+    R_homog = ut.make_homogeneous_transform(R, translation)
+    pts_homog = ut.prepare_data_for_homogeneous_transform(pts)
+    # Transposed because points are assumed to be row vectors
+    transformed_pts_homog = pts_homog @ R_homog.T
+    return ut.extract_data_for_homogeneous_transform(transformed_pts_homog)
+
+
+def inverse_rotate_translate(R, translation):
+    tinv = -translation @ R
+    return R.T, tinv
+
+
+def transform_reticle_to_probe(reticle_pts, R, translation):
+    """
+    Transform reticle points to probe points using rotation and translation.
+
+    Parameters
+    ----------
+    probe_pts : np.array(N,3)
+        Probe points to transform.
+    R : np.array(3,3)
+        Rotation matrix.
+    translation : np.array(3,)
+        Translation vector.
+
+    Returns
+    -------
+    np.array(N,3)
+        Transformed points.
+    """
+    return apply_rotate_translate(reticle_pts, R, translation)
+
+
+def transform_probe_to_reticle(probe_pts, R, translation):
+    """
+    Transform probe points to reticle points using rotation and translation.
+
+    Parameters
+    ----------
+    probe_pts : np.array(N,3)
+        Probe points to transform.
+    R : np.array(3,3)
+        Rotation matrix.
+    translation : np.array(3,)
+        Translation vector.
+
+    Returns
+    -------
+    np.array(N,3)
+        Transformed points.
+    """
+    Rinv, tinv = inverse_rotate_translate(R, translation)
+    return apply_rotate_translate(probe_pts, Rinv, tinv)

--- a/src/aind_mri_utils/rotations.py
+++ b/src/aind_mri_utils/rotations.py
@@ -197,7 +197,8 @@ def roll(input_mat, angle):  # rotation around x axis (bank angle)
 
 def pitch(input_mat, angle):  # rotation around y axis (elevation angle)
     """
-    Apply a rotation around the y-axis (pitch/elevation angle) to the input matrix.
+    Apply a rotation around the y-axis (pitch/elevation angle) to the input
+    matrix.
 
     Parameters
     ----------

--- a/src/aind_mri_utils/rotations.py
+++ b/src/aind_mri_utils/rotations.py
@@ -168,3 +168,104 @@ def rotation_matrix_from_vectors(a, b):
     ax = ut.skew_symmetric_cross_product_matrix(v)
     rotmat = np.eye(nd) + ax + ax @ ax * (1 / (1 + c))
     return rotmat
+
+
+def _rotate_mat_by_single_euler(mat, axis, angle):
+    "Helper function that rotates a matrix by a single Euler angle"
+    rotmat = Rotation.from_euler(axis, angle).as_matrix().squeeze()
+    return mat @ rotmat
+
+
+def roll(input_mat, angle):  # rotation around x axis (bank angle)
+    """
+    Apply a rotation around the x-axis (roll/bank angle) to the input matrix.
+
+    Parameters
+    ----------
+    input_mat : numpy.ndarray
+        The input matrix to be rotated.
+    angle : float
+        The angle of rotation around the x-axis in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        The rotated matrix.
+    """
+    return _rotate_mat_by_single_euler(input_mat, "x", angle)
+
+
+def pitch(input_mat, angle):  # rotation around y axis (elevation angle)
+    """
+    Apply a rotation around the y-axis (pitch/elevation angle) to the input matrix.
+
+    Parameters
+    ----------
+    input_mat : numpy.ndarray
+        The input matrix to be rotated.
+    angle : float
+        The angle of rotation around the y-axis in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        The rotated matrix.
+    """
+    return _rotate_mat_by_single_euler(input_mat, "y", angle)
+
+
+def yaw(input_mat, angle):  # rotation around z axis (heading angle)
+    """
+    Apply a rotation around the z-axis (yaw/heading angle) to the input matrix.
+
+    Parameters
+    ----------
+    input_mat : numpy.ndarray
+        The input matrix to be rotated.
+    angle : float
+        The angle of rotation around the z-axis in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        The rotated matrix.
+    """
+    return _rotate_mat_by_single_euler(input_mat, "z", angle)
+
+
+def extract_angles(mat):
+    """
+    Extract the Euler angles (roll, pitch, yaw) from a rotation matrix.
+
+    Parameters
+    ----------
+    mat : numpy.ndarray
+        The rotation matrix from which to extract the Euler angles.
+
+    Returns
+    -------
+    tuple of float
+        The extracted Euler angles (roll, pitch, yaw) in radians.
+    """
+    return tuple(Rotation.from_matrix(mat).as_euler("xyz"))
+
+
+def combine_angles(x, y, z):
+    """
+    Combine Euler angles (roll, pitch, yaw) into a rotation matrix.
+
+    Parameters
+    ----------
+    x : float
+        The roll angle (rotation around the x-axis) in radians.
+    y : float
+        The pitch angle (rotation around the y-axis) in radians.
+    z : float
+        The yaw angle (rotation around the z-axis) in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        The resulting rotation matrix.
+    """
+    return Rotation.from_euler("xyz", [x, y, z]).as_matrix().squeeze()

--- a/src/aind_mri_utils/utils.py
+++ b/src/aind_mri_utils/utils.py
@@ -205,7 +205,7 @@ def extract_data_for_homogeneous_transform(pts_homog):
         pts = pts_homog[0:M]
     elif nd == 2:
         N, M = pts_homog.shape
-        pts = pts_homog[:, 0 : (M - 1)]
+        pts = pts_homog[:, 0 : (M - 1)]  # noqa: E203
     else:
         raise ValueError("pts_homog must be 1D or 2D")
     return pts

--- a/src/aind_mri_utils/utils.py
+++ b/src/aind_mri_utils/utils.py
@@ -128,3 +128,84 @@ def unsigned_angle(a, b):
     an = norm_vec(a)
     bn = norm_vec(b)
     return np.arccos(np.clip(np.dot(an, bn), -1.0, 1.0))
+
+
+def make_homogeneous_transform(R, translation):
+    """
+    Combines a rotation matrix and translation into a homogeneous transform.
+
+    Parameters
+    ----------
+    R : np.array(N,N)
+        Rotation matrix.
+    translation : np.array(N,)
+        Translation vector.
+
+    Returns
+    -------
+    np.array(N+1,N+1)
+        homogeneous transformation matrix
+    """
+    N, M = R.shape
+    if N != M:
+        raise ValueError("R must be square")
+    if N != translation.shape[0]:
+        raise ValueError("R and translation must have same size")
+    R_homog = np.eye(N + 1)
+    R_homog[0:N, 0:N] = R
+    R_homog[0:N, N] = translation
+    return R_homog
+
+
+def prepare_data_for_homogeneous_transform(pts):
+    """
+    Prepare points for homogeneous transformation.
+
+    Parameters
+    ----------
+    pts : np.array(N,M) or np.array(M)
+        array of N M-D points.
+
+    Returns
+    -------
+    np.array(N,M+1) or np.array(M+1)
+        (M+1)-D points with 1 in the last position.
+    """
+    nd = pts.ndim
+    if nd == 1:
+        M = pts.shape[0]
+        pts_homog = np.ones(M + 1)
+        pts_homog[0:M] = pts
+    elif nd == 2:
+        N, M = pts.shape
+        pts_homog = np.ones((N, M + 1))
+        pts_homog[:, 0:M] = pts
+    else:
+        raise ValueError("pts must be 1D or 2D")
+    return pts_homog
+
+
+def extract_data_for_homogeneous_transform(pts_homog):
+    """
+    Extract points formatted for homogeneous transformation.
+
+    Parameters
+    ----------
+    pts_homog : np.array(N,M+1) or np.array(M+1)
+        (M+1)-D points with 1 in the last position.
+
+    Returns
+    -------
+    np.array(N,M) or np.array(M)
+        array of N M-D points.
+    """
+    nd = pts_homog.ndim
+    if nd == 1:
+        M = pts_homog.shape[0] - 1
+        pts = pts_homog[0:M]
+    elif nd == 2:
+        N, M = pts_homog.shape
+        pts = pts_homog[:, 0 : (M - 1)]
+    else:
+        raise ValueError("pts_homog must be 1D or 2D")
+    return pts


### PR DESCRIPTION
Add code from the mri-registration rotation file, and also code for fitting rotations to reticle calibrations.

In the process, I cleaned up both sets of code. In particular, the outputs of `fit_rotation_params` have been changed to return the regular rotation matrix and the translation in the probe frame. The old outputs are accessible by using the `legacy_outputs=True` parameter.