### PR TITLE
Return an empty array from find_indices_equal_to if none are found

### DIFF
--- a/src/aind_mri_utils/sitk_volume.py
+++ b/src/aind_mri_utils/sitk_volume.py
@@ -184,6 +184,8 @@ def find_points_equal_to(simage, val):
     """
     arr = sitk.GetArrayViewFromImage(simage)
     ndxs = ut.find_indices_equal_to(arr, val)
+    if ndxs.size == 0:
+        return np.empty((0, 3))
     ndxs_xyz = ndxs[
         :, [2, 1, 0]
     ]  # convert between numpy and simpleITK indexing


### PR DESCRIPTION
Numpy changed its behavior when indexing into an empty array with a slice. I added a check if the index array was empty, and will explicitly return an empty array if no indices are found.