### PR TITLE
Close workbook during calibration

### DIFF
--- a/src/aind_mri_utils/planning.py
+++ b/src/aind_mri_utils/planning.py
@@ -8,9 +8,7 @@ from .arc_angles import (
     calculate_arc_angles,
     transform_matrix_from_angles_and_target,
 )
-from .file_io.slicer_files import (
-    get_segmented_labels,
-)
+from .file_io.slicer_files import get_segmented_labels
 from .meshes import apply_transform_to_trimesh, create_uv_spheres
 from .sitk_volume import find_points_equal_to
 

--- a/src/aind_mri_utils/reticle_calibrations.py
+++ b/src/aind_mri_utils/reticle_calibrations.py
@@ -3,6 +3,8 @@ Functions to read reticle calibration data, find a transformation between
 coordinate frames, and apply the transformation.
 """
 
+import io
+
 import numpy as np
 from openpyxl import load_workbook
 from scipy import optimize as opt
@@ -226,7 +228,10 @@ def read_reticle_calibration(
     ValueError
         If the specified sheets are not found in the Excel file.
     """
-    wb = load_workbook(filename, read_only=True, data_only=True)
+    in_mem_file = None
+    with open(filename, "rb") as f:
+        in_mem_file = io.BytesIO(f.read())
+    wb = load_workbook(in_mem_file, read_only=True, data_only=True)
     if points_sheet_name not in wb.sheetnames:
         raise ValueError(f"Sheet {points_sheet_name} not found in {filename}")
     if metadata_sheet_name not in wb.sheetnames:


### PR DESCRIPTION
openpyxl would not close read-only notebooks. The fix is to apparently copy the entire file to memory, as the `close` function does not work for read-only files.