### PR TITLE
Remove extra reference to append_ones_column

### DIFF
--- a/src/aind_mri_utils/optimization.py
+++ b/src/aind_mri_utils/optimization.py
@@ -37,23 +37,6 @@ for version in headframe_hole_locations:
     )
 
 
-def append_ones_column(data):
-    """
-    Add a column of ones to the end of a matrix.
-
-    Parameters
-    ----------
-    data : np.array
-        Data to append a column of ones to.
-
-    Returns
-    -------
-    np.array
-        Data with a column of ones appended to the end.
-    """
-    return rot.prepare_data_for_homogeneous_transform(data)
-
-
 def _unpack_theta_apply_transform(theta, moving):
     """Helper function to apply a transform to a set of points."""
     R = rot.combine_angles(*theta[0:3])

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -3,7 +3,6 @@ import unittest
 import numpy as np
 
 from aind_mri_utils.optimization import (
-    append_ones_column,
     get_headframe_hole_lines,
     optimize_transform_labeled_lines,
     optimize_transform_labeled_lines_with_plane,
@@ -50,21 +49,6 @@ class OptimaizationTest(unittest.TestCase):
 
         # Test that value error is raised if bad version in passed
         self.assertRaises(ValueError, get_headframe_hole_lines, version=12)
-
-    def test_append_ones_column(self) -> None:
-        """
-        Tests append_ones_column
-
-        Note that copilot wrote this function... so it's probably fine
-        """
-        test_array = np.array([[1, 2, 3], [4, 5, 6]])
-        test_array = append_ones_column(test_array)
-        self.assertTrue(np.array_equal(test_array[:, 3], np.array([1, 1])))
-        self.assertTrue(
-            np.array_equal(
-                test_array[:, 0:3], np.array([[1, 2, 3], [4, 5, 6]])
-            )
-        )
 
     def test_optimize_transform_labeled_lines(self) -> None:
         """

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -10,6 +10,7 @@ import unittest
 import numpy as np
 
 from aind_mri_utils import rotations
+from aind_mri_utils.rotations import prepare_data_for_homogeneous_transform
 
 
 class RotationsTest(unittest.TestCase):
@@ -89,6 +90,21 @@ class RotationsTest(unittest.TestCase):
         self.assertTrue(np.allclose(rotmat, -np.eye(a.size)))
         self.assertRaises(
             ValueError, rotations.rotation_matrix_from_vectors, a, np.zeros(1)
+        )
+
+    def test_prepare_data_for_homogeneous_transform(self) -> None:
+        """
+        Tests prepare_data_for_homogeneous_transform
+
+        Note that copilot wrote this function... so it's probably fine
+        """
+        test_array = np.array([[1, 2, 3], [4, 5, 6]])
+        test_array = prepare_data_for_homogeneous_transform(test_array)
+        self.assertTrue(np.array_equal(test_array[:, 3], np.array([1, 1])))
+        self.assertTrue(
+            np.array_equal(
+                test_array[:, 0:3], np.array([[1, 2, 3], [4, 5, 6]])
+            )
         )
 
 


### PR DESCRIPTION
Remove duplicate alias for `append_ones_column`, and change test to test the base function instead of the alias.