### PR TITLE
Fit implants to mri segmentations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   'SimpleITK >= 2, < 3',
   'openpyxl >= 3, < 4',
   'trimesh >= 4, < 5',
+  'Rtree >= 1, < 2',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,22 +8,22 @@ description = "MRI utilities library for aind teams."
 license = { text = "MIT" }
 requires-python = ">=3.7"
 authors = [
-    { name = "Allen Institute for Neural Dynamics" },
-    { name = "Galen Lynch", email = "galen@galenlynch.com" },
-    { name = "Yoni Browning", email = "yoni.browning@alleninstitute.org" },
+  { name = "Allen Institute for Neural Dynamics" },
+  { name = "Galen Lynch", email = "galen@galenlynch.com" },
+  { name = "Yoni Browning", email = "yoni.browning@alleninstitute.org" },
 ]
 classifiers = ["Programming Language :: Python :: 3"]
 readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'matplotlib >= 3, < 4',
-    'numpy >= 1.7, < 3',
-    'pywavefront >= 1.3, < 2',
-    'scipy >= 1, < 2',
-    'SimpleITK >= 2, < 3',
-    'openpyxl >= 3, < 4',
-    'trimesh >= 4, < 5',
+  'matplotlib >= 3, < 4',
+  'numpy >= 1.7, < 3',
+  'pywavefront >= 1.3, < 2',
+  'scipy >= 1, < 2',
+  'SimpleITK >= 2, < 3',
+  'openpyxl >= 3, < 4',
+  'trimesh >= 4, < 5',
 ]
 
 [project.optional-dependencies]

--- a/src/aind_mri_utils/implant.py
+++ b/src/aind_mri_utils/implant.py
@@ -108,7 +108,7 @@ def fit_implant_to_mri(hole_seg_dict, hole_mesh_dict, initialization_hole=4):
     output = fmin(
         _implant_cost_fun,
         T,
-        args=(hole_mesh_dict, hole_seg_dict),  # ,hole_plot_dict),
+        args=(hole_mesh_dict, hole_seg_dict),
         xtol=1e-6,
         maxiter=2000,
     )

--- a/src/aind_mri_utils/implant.py
+++ b/src/aind_mri_utils/implant.py
@@ -72,8 +72,8 @@ def _implant_cost_fun(T, hole_mesh_dict, hole_seg_dict):
     total_distance = 0.0
     with ProcessPoolExecutor() as executor:
         futures = [executor.submit(func, *args) for func, args in tasks]
-        for result in as_completed(futures):
-            distances, _ = result.result()
+        for future in as_completed(futures):
+            distances, _ = future.result()
             total_distance += np.sum(distances)
     return total_distance
 

--- a/src/aind_mri_utils/implant.py
+++ b/src/aind_mri_utils/implant.py
@@ -10,10 +10,7 @@ from aind_mri_utils.meshes import (
     distance_to_all_triangles_in_mesh,
     distance_to_closest_point_for_each_triangle_in_mesh,
 )
-from aind_mri_utils.rotations import (
-    combine_angles,
-    apply_rotate_translate,
-)
+from aind_mri_utils.rotations import apply_rotate_translate, combine_angles
 from aind_mri_utils.sitk_volume import find_points_equal_to
 
 

--- a/src/aind_mri_utils/implant.py
+++ b/src/aind_mri_utils/implant.py
@@ -1,16 +1,22 @@
 """Module to fit implant rotations to MRI data."""
 
+import warnings
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import numpy as np
 from scipy.optimize import fmin
+from scipy.spatial.transform import Rotation
 
 from aind_mri_utils.file_io.slicer_files import get_segmented_labels
 from aind_mri_utils.meshes import (
     distance_to_all_triangles_in_mesh,
     distance_to_closest_point_for_each_triangle_in_mesh,
 )
-from aind_mri_utils.rotations import apply_rotate_translate, combine_angles
+from aind_mri_utils.rotations import (
+    apply_rotate_translate,
+    combine_angles,
+    rotation_matrix_from_vectors,
+)
 from aind_mri_utils.sitk_volume import find_points_equal_to
 
 
@@ -69,7 +75,12 @@ def _implant_cost_fun(T, hole_mesh_dict, hole_seg_dict, run_parallel=True):
     return total_distance
 
 
-def fit_implant_to_mri(hole_seg_dict, hole_mesh_dict, initialization_hole=4):
+def fit_implant_to_mri(
+    hole_seg_dict,
+    hole_mesh_dict,
+    initialization_hole=4,
+    other_init_holes=[3, 9],
+):
     """
     Fits an implant model to MRI data by optimizing the alignment of hole
     segments.
@@ -85,6 +96,9 @@ def fit_implant_to_mri(hole_seg_dict, hole_mesh_dict, initialization_hole=4):
         face has key -1.
     initialization_hole : int, optional
         The hole to use for initialization, by default 4.
+    other_init_holes : int, optional
+        The hole to use for initialization of the rotation, by default [3, 9].
+
 
     Returns
     -------
@@ -92,10 +106,53 @@ def fit_implant_to_mri(hole_seg_dict, hole_mesh_dict, initialization_hole=4):
         The optimized transformation parameters that align the implant model to
         the MRI data.
     """
-    annotation_mean = np.mean(hole_seg_dict[initialization_hole], axis=0)
-    model_mean = np.mean(hole_mesh_dict[initialization_hole].vertices, axis=0)
-    init_offset = model_mean - annotation_mean
-    T = [0, 0, 0, init_offset[0], init_offset[1], init_offset[2]]
+    T = np.zeros(6)
+    initialize_translation = initialization_hole in hole_seg_dict
+    if initialize_translation:
+        annotation_mean = np.mean(hole_seg_dict[initialization_hole], axis=0)
+        model_mean = np.mean(
+            hole_mesh_dict[initialization_hole].vertices, axis=0
+        )
+        init_offset = model_mean - annotation_mean
+        T[3:] = init_offset
+    else:
+        warnings.warn(
+            f"Could not find hole {initialization_hole} in MRI data "
+            "for initialization"
+        )
+
+    # Initial guess of rotation
+    initialize_rotation = initialize_translation and len(other_init_holes) >= 2
+    for other_hole in other_init_holes:
+        initialize_rotation = (
+            initialize_rotation
+            and other_hole in hole_seg_dict
+            and other_hole != initialization_hole
+        )
+        if not initialize_rotation:
+            break
+
+    if initialize_rotation:
+        # Initialize rotation based on pairs of holes
+        #
+        # Find the rotation that aligns the vector between the first two holes
+        # in the annotation to the vector between the first two holes in the
+        # model. Refine with subsequent pairs of holes.
+        R_init = np.eye(3)
+        for other_hole in other_init_holes:
+            other_anno_mean = np.mean(hole_seg_dict[other_hole], axis=0)
+            other_model_mean = np.mean(
+                hole_mesh_dict[other_hole].vertices, axis=0
+            )
+            anno_diff_rotated = R_init @ (other_anno_mean - annotation_mean)
+            R_update = rotation_matrix_from_vectors(
+                anno_diff_rotated,
+                other_model_mean - model_mean,
+            )
+            R_init = R_update @ R_init
+        T[:3] = Rotation.from_matrix(R_init).as_euler("xyz")
+    else:
+        warnings.warn("Could not find holes for rotation initialization")
 
     output = fmin(
         _implant_cost_fun,

--- a/src/aind_mri_utils/implant.py
+++ b/src/aind_mri_utils/implant.py
@@ -1,0 +1,201 @@
+"""Module to fit implant rotations to MRI data."""
+
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import numpy as np
+import SimpleITK as sitk
+import trimesh
+from scipy.optimize import fmin
+
+from aind_mri_utils import coordinate_systems as cs
+from aind_mri_utils.file_io.slicer_files import get_segmented_labels
+from aind_mri_utils.meshes import (
+    distance_to_all_triangles_in_mesh,
+    distance_to_closest_point_for_each_triangle_in_mesh,
+)
+from aind_mri_utils.rotations import (
+    create_homogeneous_from_euler_and_translation,
+    prepare_data_for_homogeneous_transform,
+)
+from aind_mri_utils.sitk_volume import find_points_equal_to
+
+
+def _implant_cost_fun(T, hole_mesh_dict, hole_seg_dict):
+    """
+    Computes the total distance cost for implant alignment based on the
+    provided transformation parameters.
+
+    Parameters
+    ----------
+    T : array-like
+        Transformation parameters including Euler angles and translation
+        vector.
+    hole_mesh_dict : dict
+        Dictionary where keys are hole IDs and values are mesh objects
+        representing the holes.
+    hole_seg_dict : dict
+        Dictionary where keys are hole IDs and values are segmented points
+        corresponding to the holes.
+
+    Returns
+    -------
+    float
+        The total distance cost calculated by summing the distances between
+        transformed points and mesh triangles.
+    """
+    trans = create_homogeneous_from_euler_and_translation(*T)
+
+    tasks = []
+    for hole_id in hole_mesh_dict.keys():
+        if hole_id not in hole_seg_dict.keys():
+            continue
+        if hole_id != -1:
+            this_hole_mesh = hole_mesh_dict[hole_id]
+            these_hole_pts = hole_seg_dict[hole_id]
+
+            transformed_hole_pts = np.dot(
+                prepare_data_for_homogeneous_transform(these_hole_pts), trans
+            )
+            func = distance_to_all_triangles_in_mesh
+            args = (this_hole_mesh, transformed_hole_pts)
+            tasks.append((func, args))
+        elif hole_id == -1:
+            lower_mesh = hole_mesh_dict[hole_id]
+            brain_outline = hole_seg_dict[hole_id]
+            transformed_brain_outline = np.dot(
+                prepare_data_for_homogeneous_transform(brain_outline), trans
+            )
+            func = distance_to_closest_point_for_each_triangle_in_mesh
+            args = (lower_mesh, transformed_brain_outline)
+            tasks.append((func, args))
+    total_distance = 0.0
+    with ProcessPoolExecutor() as executor:
+        futures = [executor.submit(func, *args) for func, args in tasks]
+        for result in as_completed(futures):
+            distances, _ = result.result()
+            total_distance += np.sum(distances)
+    return total_distance
+
+
+def fit_implant_to_mri(hole_seg_dict, hole_mesh_dict, initialization_hole=4):
+    """
+    Fits an implant model to MRI data by optimizing the alignment of hole
+    segments.
+
+    Parameters
+    ----------
+    hole_seg_dict : dict
+        Dictionary containing segmented hole data from MRI. Keys are hole
+        identifiers, and values are numpy arrays of coordinates.
+    hole_mesh_dict : dict
+        Dictionary containing mesh data for the implant model. Keys are hole
+        identifiers, and values are mesh objects with vertex coordinates.
+    initialization_hole : int, optional
+        The hole to use for initialization, by default 4.
+
+    Returns
+    -------
+    output : ndarray
+        The optimized transformation parameters that align the implant model to
+        the MRI data.
+    """
+    annotation_mean = np.mean(hole_seg_dict[initialization_hole], axis=0)
+    model_mean = np.mean(hole_mesh_dict[initialization_hole].vertices, axis=0)
+    init_offset = model_mean - annotation_mean
+    T = [0, 0, 0, init_offset[0], init_offset[1], init_offset[2]]
+
+    output = fmin(
+        _implant_cost_fun,
+        T,
+        args=(hole_mesh_dict, hole_seg_dict),  # ,hole_plot_dict),
+        xtol=1e-6,
+        maxiter=2000,
+    )
+    return output
+
+
+def make_hole_mesh_dict(hole_files, lower_face_file):
+    """
+    Creates a dictionary of hole meshes and a lower face mesh.
+
+    Parameters
+    ----------
+    hole_files : list of str
+        List of file paths to the hole mesh files.
+    lower_face_file : str
+        File path to the lower face mesh file.
+
+    Returns
+    -------
+    dict
+        A dictionary where the keys are hole numbers (int) and the values are
+        the corresponding trimesh objects. The lower face mesh is stored with
+        the key -1.
+    """
+    hole_mesh_dict = {}
+    for file_name in hole_files:
+        file_stem = Path(file_name).stem
+        hole_num = int(file_stem.split("Hole")[-1])
+        mesh = trimesh.load(file_name)
+        mesh.vertices = cs.convert_coordinate_system(
+            mesh.vertices, "ASR", "LPS"
+        )
+        hole_mesh_dict[hole_num] = mesh
+
+    # Get the lower face, store with key -1
+    hole_mesh_dict[-1] = trimesh.load(lower_face_file)
+    hole_mesh_dict[-1].vertices = cs.convert_coordinate_system(
+        hole_mesh_dict[-1].vertices, "ASR", "LPS"
+    )  # Preserves shape!
+
+    return hole_mesh_dict
+
+
+def make_hole_seg_dict(implant_annotations):
+    """
+    Creates a dictionary mapping hole names to their segmented positions.
+
+    Parameters
+    ----------
+    implant_annotations : numpy.ndarray
+        An array containing the implant annotations.
+
+    Returns
+    -------
+    dict
+        A dictionary where the keys are hole names (as integers) and the values
+        are lists of positions where the segmented values are found.
+    """
+    implant_annotations_names = get_segmented_labels(implant_annotations)
+    hole_seg_dict = {}
+    for hole_name, seg_val in implant_annotations_names.items():
+        positions = find_points_equal_to(implant_annotations, seg_val)
+        hole_seg_dict[int(hole_name)] = positions
+    return hole_seg_dict
+
+
+def fit_implant_to_mri_from_files(
+    implant_annotations_file, hole_files, lower_face_file
+):
+    """
+    Fits an implant to MRI data using provided files.
+
+    Parameters
+    ----------
+    implant_annotations_file : str or Path
+        Path to the file containing implant annotations.
+    hole_files : list of str or list of Path
+        List of paths to the files containing hole data.
+    lower_face_file : str or Path
+        Path to the file containing lower face data.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the fitted implant data.
+    """
+    implant_annotations = sitk.ReadImage(str(implant_annotations_file))
+    hole_mesh_dict = make_hole_mesh_dict(hole_files, lower_face_file)
+    hole_seg_dict = make_hole_seg_dict(implant_annotations)
+    return fit_implant_to_mri(hole_seg_dict, hole_mesh_dict)

--- a/src/aind_mri_utils/meshes.py
+++ b/src/aind_mri_utils/meshes.py
@@ -88,18 +88,18 @@ def create_uv_spheres(positions, radius=0.25, color=[255, 0, 255, 255]):
     return meshes
 
 
-def distance_to_triangle(triangle, points):
+def distances_to_triangle(points, triangle):
     """
     Calculate the distance from a set of points to a triangle.
 
     Parameters
     ----------
-    triangle : array-like, shape (3, 3)
-        The vertices of the triangle. Each row represents a vertex with x, y, z
-        coordinates.
     points : array-like, shape (n, 3)
         The points from which the distance to the triangle is calculated. Each
         row represents a point with x, y, z coordinates.
+    triangle : array-like, shape (3, 3)
+        The vertices of the triangle. Each row represents a vertex with x, y, z
+        coordinates.
 
     Returns
     -------
@@ -115,7 +115,7 @@ def distance_to_triangle(triangle, points):
     return distances, nearest_points
 
 
-def distance_to_all_triangles_in_mesh(mesh, points, normalize=1):
+def distance_to_all_triangles_in_mesh(mesh, points, normalize=True):
     """Calculate the distances from points to all triangles in a mesh.
 
     This function computes the minimum distance between a set of points and
@@ -129,14 +129,14 @@ def distance_to_all_triangles_in_mesh(mesh, points, normalize=1):
     points : numpy.ndarray
         Array of points to calculate distances from, shape (N, 3) where N is
         number of points
-    normalize : int, optional
-        Whether to normalize distances by number of points, by default 1
+    normalize : boolean, optional
+        Whether to normalize distances by number of points, by default True
 
     Returns
     -------
     distances : numpy.ndarray
         Array of distances from points to each triangle in the mesh
-        If normalize=1, distances are divided by number of points
+        If normalize=True, distances are divided by number of points
     nearest_points : list
         List of arrays containing the nearest points on each triangle for each
         input point
@@ -149,8 +149,8 @@ def distance_to_all_triangles_in_mesh(mesh, points, normalize=1):
     distances = []
     nearest_points = []
     for triangle in mesh.triangles:
-        this_distance, this_nearest_points = distance_to_triangle(
-            triangle, points
+        this_distance, this_nearest_points = distances_to_triangle(
+            points, triangle
         )
         distances.append(this_distance)
         nearest_points.append(this_nearest_points)
@@ -161,7 +161,7 @@ def distance_to_all_triangles_in_mesh(mesh, points, normalize=1):
 
 
 def distance_to_closest_point_for_each_triangle_in_mesh(
-    mesh, points, normalize=1
+    mesh, points, normalize=True
 ):
     """
     Calculate the distance to the closest point for each triangle in a mesh.
@@ -172,9 +172,9 @@ def distance_to_closest_point_for_each_triangle_in_mesh(
         A mesh object that contains triangles.
     points : array-like
         An array of points to calculate the distance from.
-    normalize : int, optional
-        If set to 1, the distances will be normalized by the number of
-        triangles (default is 1).
+    normalize : boolean, optional
+        If set to True, the distances will be normalized by the number of
+        triangles (default is True).
 
     Returns
     -------
@@ -194,8 +194,8 @@ def distance_to_closest_point_for_each_triangle_in_mesh(
     distances = []
     nearest_points = []
     for triangle in triangles:
-        distances_to_tri, nearest_points_tri = distance_to_triangle(
-            triangle, points
+        distances_to_tri, nearest_points_tri = distances_to_triangle(
+            points, triangle
         )
         min_ndx = np.argmin(distances_to_tri)
         distances.append(distances_to_tri[min_ndx])


### PR DESCRIPTION
This converts a notebook in aind-mri-targeting into a module in aind-mri-utils.

Removed Joblib dependency in favor of standard-library dependency `concurrent.futures`, renamed some variables, and added docstrings.

See related: AllenNeuralDynamics/aind-mri-targeting#13