### PR TITLE
fix: Make combine_parallax_manual calibration not require parallax

### DIFF
--- a/src/aind_mri_utils/reticle_calibrations.py
+++ b/src/aind_mri_utils/reticle_calibrations.py
@@ -1245,10 +1245,7 @@ def _validate_combined_calibration_inputs(
             raise ValueError("No manual calibration files provided")
     else:
         manual_calibration_files = [manual_calibration_files]
-    if isinstance(parallax_directories, list):
-        if len(parallax_directories) == 0:
-            raise ValueError("No parallax directories provided")
-    else:
+    if not isinstance(parallax_directories, list):
         parallax_directories = [parallax_directories]
     return manual_calibration_files, parallax_directories
 


### PR DESCRIPTION
They aren't required to get reticle metadata, so throwing an error if no parallax directories are specified is not necessary.