### PR TITLE
fix(meshes): zero-pad mask before marching cubes for watertight output

### DIFF
--- a/src/aind_mri_utils/meshes.py
+++ b/src/aind_mri_utils/meshes.py
@@ -295,8 +295,17 @@ def mask_to_trimesh(sitk_mask: sitk.Image, level: float = 0.5, smooth_iters: int
     # Get voxel data as a NumPy array
     mask_array = sitk.GetArrayFromImage(sitk_mask)  # Shape: (Z, Y, X)
 
+    # Zero-pad a one-voxel border so marching cubes can close the surface where
+    # the mask reaches the volume boundary. Without this, an object touching the
+    # array edge (e.g. a brain mask that fills the field of view) yields an open,
+    # non-watertight mesh — there is no zero voxel beyond the edge to close
+    # against. Shifting the resulting vertex indices back by one undoes the pad
+    # offset, so the mesh stays in the original image's physical space.
+    mask_array = np.pad(mask_array, 1, mode="constant", constant_values=0)
+
     # Extract surface mesh using Marching Cubes
     ndxs, faces, normals, _ = marching_cubes(mask_array, level=level)
+    ndxs = ndxs - 1  # undo the one-voxel pad → original array index space
     ndxs_sitk = ndxs[:, ::-1]
 
     # Convert voxel indices to physical space


### PR DESCRIPTION
mask_to_trimesh ran skimage.marching_cubes on the raw mask array, so any object touching the volume boundary (e.g. a brain skull-strip mask that fills the field of view) produced an open, non-watertight surface — there is no zero voxel beyond the edge for marching cubes to close against. This also made point-in-mesh containment fall back to trimesh's O(N_points * N_faces) brute-force path (28k points x 118k faces ~= 110 GB → OOM).

Pad a one-voxel zero border before meshing and shift the resulting vertex indices back by one, so boundary-touching masks close into watertight meshes while the output stays in the input image's physical space (validated: interior masks are unchanged to floating-point; a boundary-touching mask goes non-watertight -> watertight).